### PR TITLE
Update URLs

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -45,10 +45,9 @@ load-env() {
 build-nginx() {
     declare nginx_install_dir=$1
     declare nginx_build_dir=/tmp/nginx-build
-
     declare nginx_url=http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz
-    declare pcre_url=http://downloads.sourceforge.net/project/pcre/pcre/$NGINX_PCRE_VERSION/pcre-$NGINX_PCRE_VERSION.tar.bz2
-    declare headers_more_url=https://github.com/agentzh/headers-more-nginx-module/archive/v$NGINX_HEADERS_MORE_VERSION.tar.gz
+    declare pcre_url=https://ftp.pcre.org/pub/pcre/pcre-$NGINX_PCRE_VERSION.tar.bz2
+    declare headers_more_url=https://github.com/openresty/headers-more-nginx-module/archive/v$NGINX_HEADERS_MORE_VERSION.tar.gz
 
     (
         set-indent


### PR DESCRIPTION
PCRE was using an unofficial mirror and Headers More was using outdated project path.